### PR TITLE
Fix DeprecationWarning: 'U' mode is deprecated

### DIFF
--- a/python/word2numberi18n/w2n.py
+++ b/python/word2numberi18n/w2n.py
@@ -41,7 +41,7 @@ class W2N:
         
         # Now analyse the configuration file for the local spoken language
         data_file = os.path.dirname(__file__)+os.sep+"data"+os.sep+"config_"+lang+".properties"
-        with codecs.open(data_file, "rU", encoding="utf-8") as number_system_data:
+        with codecs.open(data_file, "r", encoding="utf-8") as number_system_data:
             for line in number_system_data:
                 if line.startswith('#'):
                     pass


### PR DESCRIPTION
The behavior that was previously provided by the `rU` mode is now the default read behavior, U mode has been deprecated. 
https://stackoverflow.com/questions/56791545/what-is-the-non-deprecated-version-of-open-u-mode#56791818

Currently the library produces the following warning: 
`DeprecationWarning: 'U' mode is deprecated`